### PR TITLE
Add support for basic auth to work with private apk repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ vim-9.1.0359-r0.apk
 Work with private repositories:
 
 ```
-apkrane ls --latest --auth "$(chainctl auth token --audience apk.cgr.dev)" https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
+apkrane ls --latest --auth "basic:apk.cgr.dev:user:$(chainctl auth token --audience apk.cgr.dev)" https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
 ```
 
 The HTTP_AUTH environment variable can also be used:
 
 ```
-HTTP_AUTH="$(chainctl auth token --audience apk.cgr.dev)" apkrane ls --latest https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
+HTTP_AUTH="basic:apk.cgr.dev:user:$(chainctl auth token --audience apk.cgr.dev)" apkrane ls --latest https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
 ```

--- a/README.md
+++ b/README.md
@@ -77,3 +77,15 @@ Show only the most recent version of `vim`:
 apkrane ls --latest -P vim https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
 vim-9.1.0359-r0.apk
 ```
+
+Work with private repositories:
+
+```
+apkrane ls --latest --auth "$(chainctl auth token --audience apk.cgr.dev)" https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
+```
+
+The HTTP_AUTH environment variable can also be used:
+
+```
+HTTP_AUTH="$(chainctl auth token --audience apk.cgr.dev)" apkrane ls --latest https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz | head
+```

--- a/main.go
+++ b/main.go
@@ -48,7 +48,14 @@ func fetchIndex(ctx context.Context, u string, auth string) (io.ReadCloser, erro
 		return nil, err
 	}
 	if auth != "" {
-		req.SetBasicAuth("user", auth)
+		// The auth string comes in the format of basic:domain:user:password
+		// We only need the user and password. So split it out.
+		a := strings.Split(auth, ":")
+		if len(a) < 4 || a[0] != "basic" {
+			return nil, fmt.Errorf("auth string needs to be in the format of basic:domain:user:password")
+		}
+
+		req.SetBasicAuth(a[2], a[3])
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -160,7 +167,7 @@ func ls() *cobra.Command {
 	cmd.Flags().BoolVar(&latest, "latest", false, "print only the latest version of each package")
 	cmd.Flags().BoolVar(&full, "full", false, "print the full url or path")
 	cmd.Flags().BoolVar(&j, "json", false, "print each package as json")
-	cmd.Flags().StringVarP(&auth, "auth", "A", "", "the auth token to use for the request")
+	cmd.Flags().StringVarP(&auth, "auth", "A", "", "the auth string (basic:domain:user:password) to use for the request")
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func cli() *cobra.Command {
 	return cmd
 }
 
-func fetchIndex(ctx context.Context, u string) (io.ReadCloser, error) {
+func fetchIndex(ctx context.Context, u string, auth string) (io.ReadCloser, error) {
 	if u == "-" {
 		return os.Stdin, nil
 	}
@@ -46,6 +46,9 @@ func fetchIndex(ctx context.Context, u string) (io.ReadCloser, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
+	}
+	if auth != "" {
+		req.SetBasicAuth("user", auth)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -63,6 +66,7 @@ func ls() *cobra.Command {
 	var latest bool
 	var j bool
 	var packageFilter string
+	var auth string
 
 	cmd := &cobra.Command{
 		Use:     "ls",
@@ -72,9 +76,14 @@ func ls() *cobra.Command {
 			ctx := cmd.Context()
 			u := args[0]
 
+			if auth == "" {
+				// Allow using the HTTP_AUTH environment variable as well.
+				auth = os.Getenv("HTTP_AUTH")
+			}
+
 			dir := strings.TrimSuffix(u, "/APKINDEX.tar.gz")
 
-			in, err := fetchIndex(ctx, u)
+			in, err := fetchIndex(ctx, u, auth)
 			if err != nil {
 				return err
 			}
@@ -151,6 +160,7 @@ func ls() *cobra.Command {
 	cmd.Flags().BoolVar(&latest, "latest", false, "print only the latest version of each package")
 	cmd.Flags().BoolVar(&full, "full", false, "print the full url or path")
 	cmd.Flags().BoolVar(&j, "json", false, "print each package as json")
+	cmd.Flags().StringVarP(&auth, "auth", "A", "", "the auth token to use for the request")
 
 	return cmd
 }


### PR DESCRIPTION
This way one can do:

```
apkrane ls --latest --auth "$(chainctl auth token --audience apk.cgr.dev)"  https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz
```
